### PR TITLE
escape backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Best way to go about using this if you want to? Probably delete all the sublayer
 1. Clone this repository
 1. Delete the default `~/.config/karabiner` folder
 1. Create a symlink with `ln -s ~/github/mxstbr/karabiner ~/.config` (where `~/github/mxstbr/karabiner` is your local path to where you cloned the repository)
-1. [Restart karabiner_console_user_server](https://karabiner-elements.pqrs.org/docs/manual/misc/configuration-file-path/) with `launchctl kickstart -k gui/`id -u`/org.pqrs.karabiner.karabiner_console_user_server`
+1. [Restart karabiner_console_user_server](https://karabiner-elements.pqrs.org/docs/manual/misc/configuration-file-path/) with ```launchctl kickstart -k gui/`id -u`/org.pqrs.karabiner.karabiner_console_user_server```
   ```
   launchctl kickstart -k gui/`id -u`/org.pqrs.karabiner.karabiner_console_user_server
   ```


### PR DESCRIPTION
Fixes rendering of backticks. Before the backticks within the command would end and reopen the code block.

Before
<img width="641" alt="image" src="https://user-images.githubusercontent.com/1765075/192202239-03fcbc9d-cff9-4927-a05c-baab2b971db6.png">

After
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1765075/192202317-3495b78b-b280-438b-9c28-0ff7dcf212d8.png">
