### PR TITLE
Make it possible to add single-command top-level sublayers

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -21,6 +21,38 @@ export function createHyperSubLayer(
 ): Manipulator[] {
   const subLayerVariableName = generateSubLayerVariableName(sublayer_key);
 
+  const setVariableAction = {
+    set_variable: {
+      name: subLayerVariableName,
+      value: 1,
+    },
+  }
+
+  // If the object has a 'to' field, it is a leaf sublayer
+  // rather than a hyper sublayer
+  const to = commands.to ? [...commands.to, setVariableAction] : [setVariableAction]
+  const subLayerCommands = commands.to ? [] : (Object.keys(commands) as (keyof typeof commands)[]).map(
+    (command_key): Manipulator => ({
+      ...commands[command_key],
+      type: "basic" as const,
+      from: {
+        key_code: command_key,
+        modifiers: {
+          // Mandatory modifiers are *not* added to the "to" event
+          mandatory: ["any"],
+        },
+      },
+      // Only trigger this command if the variable is 1 (i.e., if Hyper + sublayer is held)
+      conditions: [
+        {
+          type: "variable_if",
+          name: subLayerVariableName,
+          value: 1,
+        },
+      ],
+    })
+  )
+
   return [
     // When Hyper + sublayer_key is pressed, set the variable to 1; on key_up, set it to 0 again
     {
@@ -47,14 +79,7 @@ export function createHyperSubLayer(
           },
         },
       ],
-      to: [
-        {
-          set_variable: {
-            name: subLayerVariableName,
-            value: 1,
-          },
-        },
-      ],
+      to,
       // This enables us to press other sublayer keys in the current sublayer
       // (e.g. Hyper + O > M even though Hyper + M is also a sublayer)
       // basically, only trigger a sublayer if no other sublayer is active
@@ -67,27 +92,7 @@ export function createHyperSubLayer(
         })),
     },
     // Define the individual commands that are meant to trigger in the sublayer
-    ...(Object.keys(commands) as (keyof typeof commands)[]).map(
-      (command_key): Manipulator => ({
-        ...commands[command_key],
-        type: "basic" as const,
-        from: {
-          key_code: command_key,
-          modifiers: {
-            // Mandatory modifiers are *not* added to the "to" event
-            mandatory: ["any"],
-          },
-        },
-        // Only trigger this command if the variable is 1 (i.e., if Hyper + sublayer is held)
-        conditions: [
-          {
-            type: "variable_if",
-            name: subLayerVariableName,
-            value: 1,
-          },
-        ],
-      })
-    ),
+    ...subLayerCommands
   ];
 }
 


### PR DESCRIPTION
This repo is incredible - thanks so much for putting it together! I always avoided Karabiner mostly because of its complicated configuration. Your project makes it so much easier to work with and so much more powerful. I'm geeking out on how much faster I'm going to be now. 

There was one big feature I found myself really wishing I had as I started playing around with it and getting used to the keyboard shortcuts. Sublayers are absolutely necessary to namespace the commands so that you can fit everything you need to - however for a few *major* shortcuts I use all the time, 10x+ more than others, I wanted to put those on their own first level. For example, for switching to VSCode I wanted to just use `hyper + c`. For Homerow search/movement, I wanted to just use `hyper + m`. This wasn't possible before but with this PR you can now do that, like this:

```
...createHyperSubLayers({
    c: app("Visual Studio Code"),
    a: app("Arc"),
    m: { to: [{ key_code: "h", modifiers: ["right_control"] }]}, // Homerow search
    u: { to: [{ key_code: "s", modifiers: ["right_control"] }]}, // Homerow scroll
    o: {
      a: app("Arc"),
      v: app("Visual Studio Code"),
      n: app("Notion"),
      ....
    },
```

Submitting it as a PR in case you / others find it useful! 