### PR TITLE
IOKit Type

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -104,12 +104,22 @@ export interface To {
     value: boolean | number | string;
   };
   mouse_key?: MouseKey;
+  /**
+   * Power Management plugin 
+   * @example: sleep system
+   * @see: {@link https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to/software_function/iokit_power_management_sleep_system/}
+   */
+  software_function?: SoftwareFunction;
 }
 
 export interface MouseKey {
   y?: number;
   x?: number;
   speed_multiplier?: number;
+}
+
+export interface SoftwareFunction {
+  iokit_power_management_sleep_system?: {};
 }
 
 export type KeyCode =


### PR DESCRIPTION
I am now using my laptop in clamshell mode and no longer have the ability to touch the power button to sleep the laptop. Karabiner offers support for power management and sleeping the device. 

This feature adds a `SoftwareFunction` to allow keybindings to control computers sleep cycle. 

An example rule could look like this:
```typescript
...
      f12: {
        to: [
          {
            software_function: {
              iokit_power_management_sleep_system: {
                delay_milliseconds: 500,
              },
            },
          },
....
```

[Resources](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to/software_function/iokit_power_management_sleep_system/)
