### PR TITLE
Add language switching utility function

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -121,6 +121,9 @@ export interface To {
    * @see: {@link https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to/software_function/iokit_power_management_sleep_system/}
    */
   software_function?: SoftwareFunction;
+  select_input_source?: {
+    language: string;
+  };
 }
 
 export interface MouseKey {

--- a/utils.ts
+++ b/utils.ts
@@ -211,3 +211,19 @@ export function rectangle(name: string): LayerCommand {
 export function app(name: string): LayerCommand {
   return open(`-a '${name}.app'`);
 }
+
+/**
+ * Shortcut for "switching to a language" command
+ */
+export function switchToLanguage(languageCode: string): LayerCommand {
+  return {
+    to: [
+      {
+        select_input_source: {
+          language: languageCode,
+        },
+      },
+    ],
+    description: `Switch keyboard language to ${languageCode}`,
+  };
+}


### PR DESCRIPTION
First of all, thanks for this amazing project! It's been really helpful to me and so the least I can do is offer any improvements that I come up with.

Currently, with default keyboard shortcuts, switching input sources is done by rotating through them with the fn key (similar to rotating through the last used apps with Cmd + Tab). This PR adds a `switchToLanguage` utility function (similar to `open`) that allows one to assign other shortcuts for specific languages. For example, this would enable the following rules.ts:

```ts
import { KarabinerRules } from './types'
import { createHyperSubLayers, switchToLanguage } from './utils'

const rules: KarabinerRules[] = [
  ...createHyperSubLayers({
    // l = "Language"
    l: {
      e: switchToLanguage('en'),
      d: switchToLanguage('de'),
    },
  }),
]
```

This PR also serves as a workaround for another issue that I have with this setup, where the fn key instantly triggers a language switch (even when used e.g. to change the volume). This allows me to disable the fn language switching, thereby getting rid of that issue.