### PR TITLE
change identifiers to array type

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -39,7 +39,7 @@ type DeviceCondition = {
     | "device_unless"
     | "device_exists_if"
     | "device_exists_unless";
-  identifiers: Identifiers;
+  identifiers: Identifiers[];
   description?: string;
 };
 


### PR DESCRIPTION
in karabiner identifiers must be an array

<img width="684" alt="изображение" src="https://github.com/user-attachments/assets/646ab72d-2655-4a9a-99ad-907e5fc0fc06" />
